### PR TITLE
chore: Go 1.25.0 へアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage 1: builder
-FROM golang:1.24.6-alpine AS builder
+FROM golang:1.25.0-alpine AS builder
 RUN apk --no-cache add ca-certificates git
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/lancelop89/youtube-trend-tracker
 
-go 1.24.6
+go 1.25.0
 
 require (
 	cloud.google.com/go v0.121.0


### PR DESCRIPTION
## 概要
Go を最新の安定版 1.25.0 にアップデートします。

## 変更内容
- go.mod のGoバージョンを 1.24.6 から 1.25.0 に更新
- Dockerfile のベースイメージを golang:1.25.0-alpine に更新  
- `go mod tidy` で依存関係を最新化

## テスト
- [ ] ローカルでビルドが成功することを確認
- [ ] Dockerイメージのビルドが成功することを確認
- [ ] テストが全て通ることを確認

## 関連Issue
- Closes #4 (実際には Go 1.24.6 は存在するバージョンでしたが、最新版へのアップデートとして対応)

🤖 Generated with [Claude Code](https://claude.ai/code)