### PR TITLE
fix: create-secret.sh のシンタックスエラーを修正

### DIFF
--- a/scripts/create-secret.sh
+++ b/scripts/create-secret.sh
@@ -14,7 +14,7 @@ fi
 if gcloud secrets describe "$SECRET_NAME" --project="$PROJECT_ID" >/dev/null 2>&1; then
     echo "Secret '$SECRET_NAME' already exists. Skipping creation."
 else
-    echo "Creating secret '$SECRET_NAME'...
+    echo "Creating secret '$SECRET_NAME'..."
     echo -n "$YOUTUBE_API_KEY" | gcloud secrets create "$SECRET_NAME" \
         --project="$PROJECT_ID" \
         --replication-policy="automatic" \


### PR DESCRIPTION
## 概要
Issue #3 で報告されたシェルスクリプトのシンタックスエラーを修正します。

## 変更内容
- scripts/create-secret.sh の17行目のダブルクォート閉じ忘れを修正

## テスト
- `bash -n` でシンタックスエラーがないことを確認済み

Fixes #3