### PR TITLE
improve: .gitignore ファイルを拡充

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,94 @@
+# Environment variables
 .env
+.env.local
+.env.*.local
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+/fetcher
+/cmd/fetcher/fetcher
+youtube-trend-tracker
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool
+*.out
+*.prof
+*.cover
+*.html
+coverage.txt
+
+# Go workspace files
+go.work
+go.work.sum
+
+# Dependency directories
+vendor/
+
+# IDE specific files
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+.DS_Store
+Thumbs.db
+
+# Build directories
+/dist/
+/build/
+/bin/
+/tmp/
+
+# Docker
+.dockerignore.local
+docker-compose.override.yml
+
+# Logs
+*.log
+logs/
+/logs
+
+# Temporary files
+*.tmp
+*.bak
+*.backup
+*.cache
+temp/
+
+# Local data
+/data/
+*.db
+*.sqlite
+
+# Terraform (if used in future)
+*.tfstate
+*.tfstate.*
+.terraform/
+terraform.tfvars
+
+# macOS
+.DS_Store
+.AppleDouble
+.LSOverride
+
+# Windows
+Thumbs.db
+ehthumbs.db
+Desktop.ini
+
+# Linux
+.directory
+.Trash-*
+
+# Project specific
+/secrets/
+*.key
+*.pem
+*.cert
+*.crt


### PR DESCRIPTION
## 概要
Issue #6 で指摘された不完全な .gitignore ファイルを改善しました。

## 変更内容
Go開発環境で一般的に除外すべきファイルを網羅的に追加:

### 追加したカテゴリ
- **Go関連**: バイナリ、テスト出力、カバレッジレポート、ワークスペースファイル
- **IDE**: VSCode、IntelliJ IDEA、Vim等の設定ファイル
- **OS固有**: macOS、Windows、Linux のシステムファイル
- **Docker**: ローカル設定のオーバーライドファイル
- **セキュリティ**: 鍵ファイル、証明書
- **その他**: ログ、一時ファイル、データベースファイル

## テスト
- 新しい .gitignore が正しく動作することを確認
- 既存のコミット済みファイルに影響がないことを確認

Fixes #6