### PR TITLE
ci(deps): Dependabot設定を追加して依存関係管理を改善 (#12)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,63 @@
+# Dependabot configuration for automated dependency updates
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    pull-request-branch-name:
+      separator: "/"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+    reviewers:
+      - "lancelot89"
+    labels:
+      - "dependencies"
+      - "go"
+    groups:
+      google-cloud:
+        patterns:
+          - "cloud.google.com/*"
+          - "google.golang.org/*"
+      
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    reviewers:
+      - "lancelot89"
+    labels:
+      - "dependencies"
+      - "ci"
+      
+  # Docker
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 3
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    reviewers:
+      - "lancelot89"
+    labels:
+      - "dependencies"
+      - "docker"


### PR DESCRIPTION
## 概要
Issue #12 の依存関係最適化とアップデート自動化を実装します。

## 変更内容
- ✅ `go mod tidy` 実行済み（変更なし）
- ✅ yaml.v3 へのアップグレード確認（既に最新版使用中）
- ✅ Dependabot設定ファイルを追加

## Dependabot設定の詳細
### 監視対象
- **Go modules**: 週次でアップデート確認
- **GitHub Actions**: CI/CDの依存関係を最新化
- **Docker**: ベースイメージの更新を監視

### 設定内容
- 実行時刻: 毎週月曜 9:00 (JST)
- PR数制限: Go=5件、Actions/Docker=各3件
- 自動グループ化: Google Cloudパッケージを1つのPRに

## テスト
- [x] Dependabot設定のYAML構文検証
- [x] GitHubリポジトリ設定でDependabotが有効化されることを確認

## 関連Issue
Fixes #12

🤖 Generated with [Claude Code](https://claude.ai/code)