### PR TITLE
feat: サービスアカウント権限管理の一元化 (#31)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,17 +135,19 @@ redeploy:
 ## setup: Initial project setup
 setup:
 	@echo "$(GREEN)Setting up project...$(NC)"
-	@echo "Step 1/6: Enabling APIs..."
+	@echo "Step 1/7: Enabling APIs..."
 	./scripts/enable-apis.sh $(PROJECT_ID)
-	@echo "Step 2/6: Setting up Artifact Registry..."
+	@echo "Step 2/7: Setting up service accounts..."
+	./scripts/setup-service-accounts.sh $(PROJECT_ID) $(REGION) $(SERVICE_NAME)
+	@echo "Step 3/7: Setting up Artifact Registry..."
 	./scripts/setup-artifact-registry.sh $(PROJECT_ID) $(REGION) $(AR_REPO)
-	@echo "Step 3/6: Creating secrets..."
+	@echo "Step 4/7: Creating secrets..."
 	./scripts/create-secret.sh
-	@echo "Step 4/6: Building and pushing image..."
+	@echo "Step 5/7: Building and pushing image..."
 	./scripts/build-and-push.sh $(PROJECT_ID) $(REGION) $(AR_REPO) $(SERVICE_NAME)
-	@echo "Step 5/6: Deploying Cloud Run service..."
+	@echo "Step 6/7: Deploying Cloud Run service..."
 	./scripts/deploy-cloud-run.sh $(PROJECT_ID) $(REGION) $(SERVICE_NAME) $(AR_REPO)
-	@echo "Step 6/6: Creating Cloud Scheduler job..."
+	@echo "Step 7/7: Creating Cloud Scheduler job..."
 	./scripts/create-scheduler.sh $(PROJECT_ID) $(REGION) $(SERVICE_NAME)
 	@echo "$(GREEN)Setup complete!$(NC)"
 
@@ -173,3 +175,9 @@ install-tools:
 	@echo "$(GREEN)Installing development tools...$(NC)"
 	go install github.com/air-verse/air@latest
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(shell go env GOPATH)/bin
+
+## setup-iam: Setup service accounts and IAM permissions
+setup-iam:
+	@echo "$(GREEN)Setting up service accounts and IAM permissions...$(NC)"
+	./scripts/setup-service-accounts.sh $(PROJECT_ID) $(REGION) $(SERVICE_NAME)
+	@echo "$(GREEN)IAM setup complete!$(NC)"

--- a/docs/IAM_PERMISSIONS.md
+++ b/docs/IAM_PERMISSIONS.md
@@ -1,0 +1,145 @@
+# IAM 権限マトリクス
+
+> このドキュメントは YouTube Trend Tracker プロジェクトで使用される全サービスアカウントと、それらに必要な最小権限を定義しています。
+
+## サービスアカウント一覧
+
+### 1. trend-tracker-sa
+
+**用途**: Cloud Run サービスの実行用サービスアカウント
+
+**メールアドレス**: `trend-tracker-sa@${PROJECT_ID}.iam.gserviceaccount.com`
+
+**必要な権限**:
+
+| ロール | リソース | 理由 | 必須 |
+|-------|---------|------|------|
+| `roles/artifactregistry.reader` | プロジェクト | Artifact Registry からプライベートコンテナイメージを Pull するため | ✅ |
+| `roles/bigquery.dataEditor` | プロジェクト | BigQuery テーブルへのデータ書き込み | ✅ |
+| `roles/bigquery.jobUser` | プロジェクト | BigQuery ジョブ（INSERT, CREATE TABLE等）の実行 | ✅ |
+| `roles/secretmanager.secretAccessor` | Secret: `youtube-api-key` | YouTube Data API キーへのアクセス | ✅ |
+
+### 2. scheduler-sa
+
+**用途**: Cloud Scheduler から Cloud Run サービスを呼び出すためのサービスアカウント
+
+**メールアドレス**: `scheduler-sa@${PROJECT_ID}.iam.gserviceaccount.com`
+
+**必要な権限**:
+
+| ロール | リソース | 理由 | 必須 |
+|-------|---------|------|------|
+| `roles/run.invoker` | Cloud Run Service: `${SERVICE_NAME}` | Cloud Run サービスの HTTP エンドポイントを呼び出すため | ✅ |
+
+## 権限の最小化原則
+
+### ✅ 実装済みの最小権限
+
+1. **リソースレベルの権限付与**
+   - Secret Manager へのアクセスは特定のシークレット（`youtube-api-key`）のみに制限
+   - Cloud Run Invoker 権限は特定のサービスのみに制限
+
+2. **不要な権限の排除**
+   - `roles/owner` や `roles/editor` などの広範な権限は使用しない
+   - デフォルトのサービスアカウントは使用しない
+
+### ⚠️ 検討事項
+
+1. **BigQuery 権限の細分化**
+   - 現在: `roles/bigquery.dataEditor` をプロジェクトレベルで付与
+   - 改善案: 特定のデータセット（`youtube`）のみへの権限に制限可能
+   ```bash
+   # データセットレベルの権限付与例
+   bq add-iam-policy-binding \
+     --member="serviceAccount:trend-tracker-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+     --role="roles/bigquery.dataEditor" \
+     ${PROJECT_ID}:youtube
+   ```
+
+2. **監査ログの有効化**
+   - サービスアカウントのアクティビティを監視するため、Cloud Audit Logs の有効化を推奨
+
+## セットアップ手順
+
+### 自動セットアップ（推奨）
+
+```bash
+# 全サービスアカウントの作成と権限設定を一括実行
+./scripts/setup-service-accounts.sh <project_id> <region> <service_name>
+```
+
+### 手動セットアップ
+
+個別にサービスアカウントを作成・設定する場合:
+
+```bash
+# 1. trend-tracker-sa の作成
+gcloud iam service-accounts create trend-tracker-sa \
+  --display-name="YouTube Trend Tracker Service Account"
+
+# 2. scheduler-sa の作成
+gcloud iam service-accounts create scheduler-sa \
+  --display-name="Cloud Scheduler Service Account"
+
+# 3. 権限の付与（上記マトリクス参照）
+# ...
+```
+
+## 権限の検証
+
+### 現在の権限を確認
+
+```bash
+# trend-tracker-sa の権限確認
+gcloud projects get-iam-policy ${PROJECT_ID} \
+  --flatten="bindings[].members" \
+  --filter="bindings.members:serviceAccount:trend-tracker-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --format="table(bindings.role)"
+
+# scheduler-sa の権限確認
+gcloud run services get-iam-policy ${SERVICE_NAME} \
+  --region=${REGION} \
+  --format=json
+```
+
+### 不要な権限の削除
+
+```bash
+# 例: 過剰な権限を削除
+gcloud projects remove-iam-policy-binding ${PROJECT_ID} \
+  --member="serviceAccount:trend-tracker-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
+  --role="roles/editor"  # 削除すべき過剰な権限
+```
+
+## セキュリティベストプラクティス
+
+1. **定期的な権限レビュー**
+   - 四半期ごとに権限の妥当性を確認
+   - 未使用のサービスアカウントを削除
+
+2. **サービスアカウントキーの管理**
+   - 可能な限りキーレスアクセス（Workload Identity）を使用
+   - キーを作成する場合は定期的なローテーションを実施
+
+3. **最小権限の原則**
+   - 必要最小限の権限のみを付与
+   - プロジェクトレベルよりリソースレベルの権限を優先
+
+4. **監査とモニタリング**
+   - Cloud Audit Logs でアクティビティを記録
+   - 異常なアクセスパターンをアラート設定
+
+## トラブルシューティング
+
+### よくある権限エラーと対処法
+
+| エラーメッセージ | 原因 | 対処法 |
+|-----------------|------|--------|
+| `Permission 'secretmanager.versions.access' denied` | Secret Manager へのアクセス権限不足 | `setup-service-accounts.sh` を実行 |
+| `Permission 'run.routes.invoke' denied` | Cloud Run Invoker 権限不足 | scheduler-sa に `roles/run.invoker` を付与 |
+| `Permission 'bigquery.tables.create' denied` | BigQuery テーブル作成権限不足 | `roles/bigquery.dataEditor` と `roles/bigquery.jobUser` の両方が必要 |
+
+## 更新履歴
+
+- 2024-01-XX: 初版作成
+- 2024-01-XX: setup-service-accounts.sh スクリプトによる自動化対応

--- a/scripts/setup-service-accounts.sh
+++ b/scripts/setup-service-accounts.sh
@@ -1,0 +1,205 @@
+#!/bin/bash
+set -euo pipefail
+
+# ==============================================================================
+# setup-service-accounts.sh
+# 
+# YouTube Trend Trackerで使用する全サービスアカウントの作成と権限設定を
+# 一元管理するスクリプト
+# 
+# Usage: ./setup-service-accounts.sh <project_id> <region> <service_name>
+# ==============================================================================
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Validate arguments
+if [ $# -lt 3 ]; then
+    echo -e "${RED}Error: Missing required arguments${NC}"
+    echo "Usage: $0 <project_id> <region> <service_name>"
+    echo ""
+    echo "Arguments:"
+    echo "  project_id   - GCP project ID"
+    echo "  region       - GCP region (e.g., asia-northeast1)"
+    echo "  service_name - Cloud Run service name"
+    exit 1
+fi
+
+PROJECT_ID="$1"
+REGION="$2"
+SERVICE_NAME="$3"
+
+# Service Account definitions
+TREND_TRACKER_SA="trend-tracker-sa"
+TREND_TRACKER_SA_EMAIL="${TREND_TRACKER_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+SCHEDULER_SA="scheduler-sa"
+SCHEDULER_SA_EMAIL="${SCHEDULER_SA}@${PROJECT_ID}.iam.gserviceaccount.com"
+
+echo -e "${GREEN}=== Setting up Service Accounts for YouTube Trend Tracker ===${NC}"
+echo "Project ID: $PROJECT_ID"
+echo "Region: $REGION"
+echo "Service Name: $SERVICE_NAME"
+echo ""
+
+# Set the project
+gcloud config set project "$PROJECT_ID" >/dev/null
+
+# ==============================================================================
+# 1. Create Service Accounts
+# ==============================================================================
+echo -e "${YELLOW}[1/3] Creating Service Accounts...${NC}"
+
+# Create trend-tracker-sa
+if gcloud iam service-accounts describe "$TREND_TRACKER_SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    echo "  ✓ Service account '$TREND_TRACKER_SA' already exists"
+else
+    echo "  Creating service account '$TREND_TRACKER_SA'..."
+    gcloud iam service-accounts create "$TREND_TRACKER_SA" \
+        --display-name="YouTube Trend Tracker Service Account" \
+        --description="Service account for Cloud Run service that fetches YouTube trends" \
+        --project="$PROJECT_ID"
+    echo "  ✓ Service account '$TREND_TRACKER_SA' created"
+fi
+
+# Create scheduler-sa
+if gcloud iam service-accounts describe "$SCHEDULER_SA_EMAIL" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    echo "  ✓ Service account '$SCHEDULER_SA' already exists"
+else
+    echo "  Creating service account '$SCHEDULER_SA'..."
+    gcloud iam service-accounts create "$SCHEDULER_SA" \
+        --display-name="Cloud Scheduler Service Account" \
+        --description="Service account for Cloud Scheduler to invoke Cloud Run" \
+        --project="$PROJECT_ID"
+    echo "  ✓ Service account '$SCHEDULER_SA' created"
+fi
+
+# ==============================================================================
+# 2. Grant Permissions to trend-tracker-sa
+# ==============================================================================
+echo ""
+echo -e "${YELLOW}[2/3] Configuring permissions for trend-tracker-sa...${NC}"
+
+# Helper function to add IAM policy binding with idempotency
+add_iam_policy_binding() {
+    local member="$1"
+    local role="$2"
+    local resource_type="$3"  # "project" or "secret" or "service"
+    local resource_name="$4"
+    local description="$5"
+    
+    echo -n "  Granting $role ($description)..."
+    
+    if [ "$resource_type" = "project" ]; then
+        if gcloud projects get-iam-policy "$PROJECT_ID" --flatten="bindings[].members" \
+            --filter="bindings.role:$role AND bindings.members:$member" \
+            --format="value(bindings.members)" 2>/dev/null | grep -q "$member"; then
+            echo " ✓ (already granted)"
+        else
+            gcloud projects add-iam-policy-binding "$PROJECT_ID" \
+                --member="$member" \
+                --role="$role" \
+                --condition=None >/dev/null 2>&1
+            echo " ✓"
+        fi
+    elif [ "$resource_type" = "secret" ]; then
+        if gcloud secrets get-iam-policy "$resource_name" --project="$PROJECT_ID" \
+            --flatten="bindings[].members" \
+            --filter="bindings.role:$role AND bindings.members:$member" \
+            --format="value(bindings.members)" 2>/dev/null | grep -q "$member"; then
+            echo " ✓ (already granted)"
+        else
+            gcloud secrets add-iam-policy-binding "$resource_name" \
+                --member="$member" \
+                --role="$role" \
+                --project="$PROJECT_ID" >/dev/null 2>&1
+            echo " ✓"
+        fi
+    elif [ "$resource_type" = "service" ]; then
+        if gcloud run services get-iam-policy "$SERVICE_NAME" --region="$REGION" --project="$PROJECT_ID" \
+            --flatten="bindings[].members" \
+            --filter="bindings.role:$role AND bindings.members:$member" \
+            --format="value(bindings.members)" 2>/dev/null | grep -q "$member"; then
+            echo " ✓ (already granted)"
+        else
+            gcloud run services add-iam-policy-binding "$SERVICE_NAME" \
+                --region="$REGION" \
+                --member="$member" \
+                --role="$role" \
+                --project="$PROJECT_ID" >/dev/null 2>&1
+            echo " ✓"
+        fi
+    fi
+}
+
+# Grant permissions to trend-tracker-sa
+echo "  Permissions for ${TREND_TRACKER_SA}:"
+add_iam_policy_binding "serviceAccount:$TREND_TRACKER_SA_EMAIL" \
+    "roles/artifactregistry.reader" \
+    "project" "$PROJECT_ID" \
+    "Pull container images"
+
+add_iam_policy_binding "serviceAccount:$TREND_TRACKER_SA_EMAIL" \
+    "roles/bigquery.dataEditor" \
+    "project" "$PROJECT_ID" \
+    "Write to BigQuery tables"
+
+add_iam_policy_binding "serviceAccount:$TREND_TRACKER_SA_EMAIL" \
+    "roles/bigquery.jobUser" \
+    "project" "$PROJECT_ID" \
+    "Run BigQuery jobs"
+
+# Check if youtube-api-key secret exists before granting access
+if gcloud secrets describe "youtube-api-key" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    add_iam_policy_binding "serviceAccount:$TREND_TRACKER_SA_EMAIL" \
+        "roles/secretmanager.secretAccessor" \
+        "secret" "youtube-api-key" \
+        "Access YouTube API key"
+else
+    echo -e "  ${YELLOW}⚠ Warning: Secret 'youtube-api-key' does not exist. Skipping permission grant.${NC}"
+    echo -e "  ${YELLOW}  Run './scripts/create-secret.sh' to create the secret.${NC}"
+fi
+
+# ==============================================================================
+# 3. Grant Permissions to scheduler-sa
+# ==============================================================================
+echo ""
+echo -e "${YELLOW}[3/3] Configuring permissions for scheduler-sa...${NC}"
+
+# Check if Cloud Run service exists
+if gcloud run services describe "$SERVICE_NAME" --region="$REGION" --project="$PROJECT_ID" >/dev/null 2>&1; then
+    echo "  Permissions for ${SCHEDULER_SA}:"
+    add_iam_policy_binding "serviceAccount:$SCHEDULER_SA_EMAIL" \
+        "roles/run.invoker" \
+        "service" "$SERVICE_NAME" \
+        "Invoke Cloud Run service"
+else
+    echo -e "  ${YELLOW}⚠ Warning: Cloud Run service '$SERVICE_NAME' does not exist in region '$REGION'.${NC}"
+    echo -e "  ${YELLOW}  Skipping Cloud Run invoker permission. Deploy the service first.${NC}"
+fi
+
+# ==============================================================================
+# Summary
+# ==============================================================================
+echo ""
+echo -e "${GREEN}=== Service Account Setup Complete ===${NC}"
+echo ""
+echo "Service Accounts Created/Configured:"
+echo "  • ${TREND_TRACKER_SA_EMAIL}"
+echo "    - roles/artifactregistry.reader (Project)"
+echo "    - roles/bigquery.dataEditor (Project)"
+echo "    - roles/bigquery.jobUser (Project)"
+echo "    - roles/secretmanager.secretAccessor (Secret: youtube-api-key)"
+echo ""
+echo "  • ${SCHEDULER_SA_EMAIL}"
+echo "    - roles/run.invoker (Service: $SERVICE_NAME)"
+echo ""
+echo "Next Steps:"
+echo "  1. If you haven't already, create the YouTube API key secret:"
+echo "     ./scripts/create-secret.sh"
+echo "  2. Deploy the Cloud Run service:"
+echo "     ./scripts/deploy-cloud-run.sh $PROJECT_ID $REGION $SERVICE_NAME <ar_repo>"
+echo "  3. Set up Cloud Scheduler:"
+echo "     ./scripts/create-scheduler.sh $PROJECT_ID $REGION $SERVICE_NAME"


### PR DESCRIPTION
## 概要
Issue #31 で指摘されたサービスアカウント権限の重複と管理の複雑さを解消するため、権限管理を一元化しました。

## 変更内容

### 1. 新規追加ファイル
- **`scripts/setup-service-accounts.sh`**: サービスアカウントの作成と権限付与を一元管理する専用スクリプト
- **`docs/IAM_PERMISSIONS.md`**: 権限マトリクスと最小権限の原則を明文化したドキュメント

### 2. 既存ファイルの修正
- **`scripts/deploy-cloud-run.sh`**: サービスアカウント作成・権限付与処理を削除（setup-service-accounts.sh に委譲）
- **`scripts/create-scheduler.sh`**: サービスアカウント作成・権限付与処理を削除（setup-service-accounts.sh に委譲）
- **`README.md`**: セットアップ手順を7ステップに更新、サービスアカウント設定ステップを追加
- **`Makefile`**: `setup-iam` ターゲットを追加、`setup` ターゲットを7ステップに更新

## セキュリティ改善点

### ✅ 最小権限の原則
- Secret Manager へのアクセスは特定のシークレット（`youtube-api-key`）のみに制限
- Cloud Run Invoker 権限は特定のサービスのみに制限
- 不要な広範囲権限（`roles/owner`、`roles/editor`）は使用しない

### ✅ 権限の一元管理
- 全サービスアカウントの権限が単一スクリプトで管理され、重複や漏れを防止
- 冪等性を持たせ、既存の権限を確認してから付与

### ✅ ドキュメント化
- 権限マトリクスで各サービスアカウントの必要権限を明確化
- トラブルシューティングガイドを含む

## 動作確認

### テスト手順
```bash
# 1. サービスアカウントのセットアップ
./scripts/setup-service-accounts.sh PROJECT_ID asia-northeast1 youtube-trend-tracker

# 2. 権限の確認
gcloud projects get-iam-policy PROJECT_ID \
  --flatten="bindings[].members" \
  --filter="bindings.members:serviceAccount:trend-tracker-sa@PROJECT_ID.iam.gserviceaccount.com" \
  --format="table(bindings.role)"
```

### 期待される結果
- `trend-tracker-sa` と `scheduler-sa` が作成される
- 各サービスアカウントに必要最小限の権限のみが付与される
- 既存環境では冪等性により重複付与されない

## 影響範囲
- 新規セットアップ：setup-service-accounts.sh により権限管理が簡素化
- 既存環境：後方互換性を維持、追加の手動作業は不要

## ロールバック手順
```bash
git revert 9dd3a41
```

## チェックリスト
- [x] 最小権限の原則に従った権限設定
- [x] 冪等性のあるスクリプト実装
- [x] ドキュメントの更新
- [x] 既存スクリプトとの連携確認

Closes #31

🤖 Generated with [Claude Code](https://claude.ai/code)