### PR TITLE
fix: Lintエラー修正 - 未使用のmock型をコメントアウト

### DIFF
--- a/internal/fetcher/fetcher_test.go
+++ b/internal/fetcher/fetcher_test.go
@@ -1,45 +1,45 @@
 package fetcher
 
 import (
-	"context"
 	"testing"
 	"time"
 
 	"cloud.google.com/go/civil"
-	"github.com/lancelop89/youtube-trend-tracker/internal/storage"
-	"github.com/lancelop89/youtube-trend-tracker/internal/youtube"
 )
 
-// Mock YouTube Client
-type mockYouTubeClient struct {
-	videos []*youtube.Video
-	err    error
-}
+// Mock implementations are commented out until dependency injection is refactored
+// These will be needed when Fetcher is updated to accept interfaces
 
-func (m *mockYouTubeClient) FetchChannelVideos(ctx context.Context, channelID string, maxResults int64) ([]*youtube.Video, error) {
-	if m.err != nil {
-		return nil, m.err
-	}
-	return m.videos, nil
-}
+// // Mock YouTube Client
+// type mockYouTubeClient struct {
+// 	videos []*youtube.Video
+// 	err    error
+// }
 
-// Mock BigQuery Writer
-type mockBigQueryWriter struct {
-	insertedRecords []*storage.VideoStatsRecord
-	err             error
-}
+// func (m *mockYouTubeClient) FetchChannelVideos(ctx context.Context, channelID string, maxResults int64) ([]*youtube.Video, error) {
+// 	if m.err != nil {
+// 		return nil, m.err
+// 	}
+// 	return m.videos, nil
+// }
 
-func (m *mockBigQueryWriter) InsertVideoStats(ctx context.Context, records []*storage.VideoStatsRecord) error {
-	if m.err != nil {
-		return m.err
-	}
-	m.insertedRecords = append(m.insertedRecords, records...)
-	return nil
-}
+// // Mock BigQuery Writer
+// type mockBigQueryWriter struct {
+// 	insertedRecords []*storage.VideoStatsRecord
+// 	err             error
+// }
 
-func (m *mockBigQueryWriter) EnsureTableExists(ctx context.Context) error {
-	return nil
-}
+// func (m *mockBigQueryWriter) InsertVideoStats(ctx context.Context, records []*storage.VideoStatsRecord) error {
+// 	if m.err != nil {
+// 		return m.err
+// 	}
+// 	m.insertedRecords = append(m.insertedRecords, records...)
+// 	return nil
+// }
+
+// func (m *mockBigQueryWriter) EnsureTableExists(ctx context.Context) error {
+// 	return nil
+// }
 
 func TestFetchAndStore_Success(t *testing.T) {
 	// This test demonstrates the need for dependency injection

--- a/internal/metrics/metrics.go
+++ b/internal/metrics/metrics.go
@@ -1,3 +1,6 @@
+// Package metrics provides Prometheus metrics for the YouTube Trend Tracker application.
+// This package will be integrated in a future update for monitoring and observability.
+// TODO: Integrate with main application in Issue #28
 package metrics
 
 import (


### PR DESCRIPTION
## 概要
- 目的 / 背景: GitHub ActionsのLintで報告されている未使用型エラーを解消
- このPRでやったこと: テストファイルの未使用mock型をコメントアウト

## 変更点
- `internal/fetcher/fetcher_test.go`: 
  - mockYouTubeClientとmockBigQueryWriterをコメントアウト
  - 未使用のimportを削除
- `internal/metrics/metrics.go`: パッケージドキュメントコメントを追加

## 動作確認
```bash
# テストの実行
go test ./internal/fetcher/...
```

## 影響範囲
- 互換性: 影響なし（コメントアウトのみ）
- 秘密情報: なし

## 今後の対応
- Issue #28でメトリクスパッケージを統合予定
- 将来的にDIを導入する際にmock型を再度有効化予定

## ロールバック
- 手順: コメントアウトを解除